### PR TITLE
Bugfix: Late start items not displayed at right position

### DIFF
--- a/projects/ng-time-chart-showcase/src/app/app.component.ts
+++ b/projects/ng-time-chart-showcase/src/app/app.component.ts
@@ -25,44 +25,44 @@ export class AppComponent {
   constructor() {
     moment.locale('de-ch');
     this.groups = [
-      // new Group(
-      //   'Testgroup 0',
-      //   [
-      //     {
-      //       name: 'Testitem 0',
-      //       startTime: moment(`${this.currentYear}-02-12`),
-      //       endTime: moment(`${this.currentYear}-03-23`),
-      //       class: 'type-b'
-      //     },
-      //     {
-      //       name: 'Testitem 1',
-      //       startTime: moment(`${this.currentYear}-03-25`),
-      //       endTime: moment(`${this.currentYear}-03-30T01:30`),
-      //       class: 'type-a',
-      //       details: 'More information of Testitem 1',
-      //       onClick: () => alert('I was clicked 😊')
-      //     },
-      //     {
-      //       name: 'Testitem 2',
-      //       startTime: moment(`${this.currentYear}-04-01`),
-      //       endTime: moment(`${this.currentYear}-04-07`),
-      //       class: 'type-b'
-      //     },
-      //     {
-      //       name: 'Testitem 3',
-      //       startTime: moment(`${this.currentYear}-04-08`),
-      //       endTime: moment(`${this.currentYear}-04-12`),
-      //       class: 'type-b'
-      //     },
-      //     {
-      //       name: 'Testitem 4',
-      //       startTime: moment(`${this.currentYear}-04-02`),
-      //       endTime: moment(`${this.currentYear}-04-05`),
-      //       class: 'type-b',
-      //       details: 'More information of Testitem 4. A lot of text to show how this is handled.'
-      //     }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
-      //   () => alert('Group clicked')
-      // ),
+      new Group(
+        'Testgroup 0',
+        [
+          {
+            name: 'Testitem 0',
+            startTime: moment(`${this.currentYear}-02-12`),
+            endTime: moment(`${this.currentYear}-03-23`),
+            class: 'type-b'
+          },
+          {
+            name: 'Testitem 1',
+            startTime: moment(`${this.currentYear}-03-25`),
+            endTime: moment(`${this.currentYear}-03-30T01:30`),
+            class: 'type-a',
+            details: 'More information of Testitem 1',
+            onClick: () => alert('I was clicked 😊')
+          },
+          {
+            name: 'Testitem 2',
+            startTime: moment(`${this.currentYear}-04-01`),
+            endTime: moment(`${this.currentYear}-04-07`),
+            class: 'type-b'
+          },
+          {
+            name: 'Testitem 3',
+            startTime: moment(`${this.currentYear}-04-08`),
+            endTime: moment(`${this.currentYear}-04-12`),
+            class: 'type-b'
+          },
+          {
+            name: 'Testitem 4',
+            startTime: moment(`${this.currentYear}-04-02`),
+            endTime: moment(`${this.currentYear}-04-05`),
+            class: 'type-b',
+            details: 'More information of Testitem 4. A lot of text to show how this is handled.'
+          }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
+        () => alert('Group clicked')
+      ),
       new Group(
         'Testgroup 1',
         [
@@ -79,211 +79,211 @@ export class AppComponent {
             endTime: moment(`${this.currentYear}-04-28T00:30`),
             details: 'Oh, there\'s a monkey in my pocket, And he\'s stealing all my change. His stare is blank and glassy, I suspect he\'s deranged 🐒',
             class: 'type-c',
-            // dates: [
-            //   moment(`${this.currentYear}-04-11`),
-            //   moment(`${this.currentYear}-04-12`),
-            //   moment(`${this.currentYear}-04-13`),
-            //   moment(`${this.currentYear}-04-14`),
-            //   moment(`${this.currentYear}-04-15`),
-            //   moment(`${this.currentYear}-04-16`),
-            //   moment(`${this.currentYear}-04-17`),
-            //   moment(`${this.currentYear}-04-18`),
-            //   moment(`${this.currentYear}-04-19`),
-            //   moment(`${this.currentYear}-04-20`),
-            //   moment(`${this.currentYear}-04-21`),
-            //   moment(`${this.currentYear}-04-22`),
-            //   moment(`${this.currentYear}-04-23`),
-            //   moment(`${this.currentYear}-04-24`),
-            //   moment(`${this.currentYear}-04-25`),
-            //   moment(`${this.currentYear}-04-26`),
-            //   moment(`${this.currentYear}-04-27`),
-            //   moment(`${this.currentYear}-04-28`)
-            // ]
+            dates: [
+              moment(`${this.currentYear}-04-11`),
+              moment(`${this.currentYear}-04-12`),
+              moment(`${this.currentYear}-04-13`),
+              moment(`${this.currentYear}-04-14`),
+              moment(`${this.currentYear}-04-15`),
+              moment(`${this.currentYear}-04-16`),
+              moment(`${this.currentYear}-04-17`),
+              moment(`${this.currentYear}-04-18`),
+              moment(`${this.currentYear}-04-19`),
+              moment(`${this.currentYear}-04-20`),
+              moment(`${this.currentYear}-04-21`),
+              moment(`${this.currentYear}-04-22`),
+              moment(`${this.currentYear}-04-23`),
+              moment(`${this.currentYear}-04-24`),
+              moment(`${this.currentYear}-04-25`),
+              moment(`${this.currentYear}-04-26`),
+              moment(`${this.currentYear}-04-27`),
+              moment(`${this.currentYear}-04-28`)
+            ]
           },
           {
             name: 'Testitem 2',
             startTime: moment(`${this.currentYear}-10-08T22:00`),
             endTime: moment(`${this.currentYear}-10-10T04:30`),
             class: 'type-b',
-            // dates: [
-            //   moment(`${this.currentYear}-10-08`),
-            //   moment(`${this.currentYear}-10-09`),
-            //   moment(`${this.currentYear}-10-10`)
-            // ]
+            dates: [
+              moment(`${this.currentYear}-10-08`),
+              moment(`${this.currentYear}-10-09`),
+              moment(`${this.currentYear}-10-10`)
+            ]
           },].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
         () => console.log('clicked')
       ),
-      // new Group(
-      //   'Testgroup 2',
-      //   [
-      //     {
-      //       name: 'Testitem 0',
-      //       startTime: moment(`${this.currentYear}-06-12`),
-      //       endTime: moment(`${this.currentYear}-07-23`)
-      //     },
-      //     {
-      //       name: 'Testitem 1',
-      //       startTime: moment(`${this.currentYear - 1}-08-11`),
-      //       endTime: moment(`${this.currentYear}-09-02`)
-      //     }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
-      //   () => console.log('clicked')
-      // ),
-      // new Group(
-      //   'Testgroup 3',
-      //   [
-      //     {
-      //       name: 'Testitem 0',
-      //       startTime: moment(`${this.currentYear}-09-12`),
-      //       endTime: moment(`${this.currentYear}-10-23`)
-      //     },
-      //     {
-      //       name: 'Testitem 1',
-      //       startTime: moment(`${this.currentYear}-10-11`),
-      //       endTime: moment(`${this.currentYear}-11-02`)
-      //     }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
-      //   () => console.log('clicked')
-      // ),
-      // new Group(
-      //   'Testgroup 4',
-      //   [
-      //     {
-      //       name: 'Testitem 0',
-      //       startTime: moment(`${this.currentYear}-02-12`),
-      //       endTime: moment(`${this.currentYear}-05-23`)
-      //     },
-      //     {
-      //       name: 'Testitem 1',
-      //       startTime: moment(`${this.currentYear}-12-11`),
-      //       endTime: moment(`${this.currentYear + 1}-03-02`)
-      //     }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
-      //   () => console.log('clicked')
-      // ),
-      // new Group(
-      //   'Testgroup 5',
-      //   [
-      //     {
-      //       name: 'Testitem 0',
-      //       startTime: moment(`${this.currentYear}-03-12`),
-      //       endTime: moment(`${this.currentYear}-03-23`)
-      //     },
-      //     {
-      //       name: 'Testitem 1',
-      //       startTime: moment(`${this.currentYear}-03-11`),
-      //       endTime: moment(`${this.currentYear}-04-02`)
-      //     },
-      //     {
-      //       name: 'Testitem 2',
-      //       startTime: moment(`${this.currentYear}-04-01`),
-      //       endTime: moment(`${this.currentYear}-04-04`)
-      //     }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
-      //   () => console.log('clicked')
-      // ),
-      // new Group(
-      //   'Testgroup 6',
-      //   [
-      //     {
-      //       name: 'Testitem 0',
-      //       startTime: moment(`${this.currentYear}-06-12`),
-      //       endTime: moment(`${this.currentYear}-07-23`),
-      //       class: 'type-c'
-      //     },
-      //     {
-      //       name: 'Testitem 1',
-      //       startTime: moment(`${this.currentYear - 1}-08-11`),
-      //       endTime: moment(`${this.currentYear}-09-02`),
-      //       class: 'type-a'
-      //     }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
-      //   () => console.log('clicked')
-      // ),
-      // new Group(
-      //   'Testgroup 7',
-      //   [
-      //     {
-      //       name: 'Testitem 0',
-      //       startTime: moment(`${this.currentYear - 1}-09-12`),
-      //       endTime: moment(`${this.currentYear - 1}-10-23`),
-      //       class: 'my-class-a'
-      //     },
-      //     {
-      //       name: 'Testitem 1',
-      //       startTime: moment(`${this.currentYear - 2}-10-11`),
-      //       endTime: moment(`${this.currentYear - 1}-11-02`),
-      //       class: 'my-class-a'
-      //     }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
-      //   () => console.log('clicked')
-      // ),
-      // new Group(
-      //   'Testgroup 8',
-      //   [
-      //     {
-      //       name: 'Testitem 0',
-      //       startTime: moment(`${this.currentYear}-02-12`),
-      //       endTime: moment(`${this.currentYear}-04-23`)
-      //     },
-      //     {
-      //       name: 'Testitem 1',
-      //       startTime: moment(`${this.currentYear}-05-11`),
-      //       endTime: moment(`${this.currentYear}-06-02`)
-      //     }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
-      //   () => console.log('clicked')
-      // ),
-      // new Group(
-      //   'Testgroup 9',
-      //   [
-      //     {
-      //       name: 'Testitem 0',
-      //       startTime: moment(`${this.currentYear}-02-12`),
-      //       endTime: moment(`${this.currentYear}-05-23`),
-      //       dates: [
-      //         moment(`${this.currentYear}-04-11`),
-      //         moment(`${this.currentYear}-04-12`)
-      //       ]
-      //     },
-      //     {
-      //       name: 'Testitem 1',
-      //       startTime: moment(`${this.currentYear}-04-11`),
-      //       endTime: moment(`${this.currentYear}-05-02`)
-      //     }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
-      //   () => console.log('clicked')
-      // ),
-      // new Group(
-      //   'Testgroup 10',
-      //   [
-      //     {
-      //       name: 'Testitem 0',
-      //       startTime: moment(`${this.currentYear}-06-12`),
-      //       endTime: moment(`${this.currentYear}-07-23`),
-      //       class: 'type-a',
-      //       dates: [
-      //         moment(`${this.currentYear}-06-18`),
-      //         moment(`${this.currentYear}-06-19`),
-      //         moment(`${this.currentYear}-06-23`),
-      //         moment(`${this.currentYear}-06-24`)
-      //       ]
-      //     },
-      //     {
-      //       name: 'Testitem 1',
-      //       startTime: moment(`${this.currentYear - 1}-08-11`),
-      //       endTime: moment(`${this.currentYear}-06-02`),
-      //       class: 'type-a'
-      //     }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
-      //   () => console.log('clicked')
-      // ),
-      // new Group(
-      //   'Testgroup 11',
-      //   [
-      //     {
-      //       name: 'Testitem 0',
-      //       startTime: moment(`${this.currentYear}-09-12`),
-      //       endTime: moment(`2021-01-23`)
-      //     },
-      //     {
-      //       name: 'Testitem 1',
-      //       startTime: moment(`${this.currentYear - 1}-10-11`),
-      //       endTime: moment(`${this.currentYear}-11-02`)
-      //     }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
-      //   () => console.log('clicked')
-      // )
+      new Group(
+        'Testgroup 2',
+        [
+          {
+            name: 'Testitem 0',
+            startTime: moment(`${this.currentYear}-06-12`),
+            endTime: moment(`${this.currentYear}-07-23`)
+          },
+          {
+            name: 'Testitem 1',
+            startTime: moment(`${this.currentYear - 1}-08-11`),
+            endTime: moment(`${this.currentYear}-09-02`)
+          }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
+        () => console.log('clicked')
+      ),
+      new Group(
+        'Testgroup 3',
+        [
+          {
+            name: 'Testitem 0',
+            startTime: moment(`${this.currentYear}-09-12`),
+            endTime: moment(`${this.currentYear}-10-23`)
+          },
+          {
+            name: 'Testitem 1',
+            startTime: moment(`${this.currentYear}-10-11`),
+            endTime: moment(`${this.currentYear}-11-02`)
+          }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
+        () => console.log('clicked')
+      ),
+      new Group(
+        'Testgroup 4',
+        [
+          {
+            name: 'Testitem 0',
+            startTime: moment(`${this.currentYear}-02-12`),
+            endTime: moment(`${this.currentYear}-05-23`)
+          },
+          {
+            name: 'Testitem 1',
+            startTime: moment(`${this.currentYear}-12-11`),
+            endTime: moment(`${this.currentYear + 1}-03-02`)
+          }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
+        () => console.log('clicked')
+      ),
+      new Group(
+        'Testgroup 5',
+        [
+          {
+            name: 'Testitem 0',
+            startTime: moment(`${this.currentYear}-03-12`),
+            endTime: moment(`${this.currentYear}-03-23`)
+          },
+          {
+            name: 'Testitem 1',
+            startTime: moment(`${this.currentYear}-03-11`),
+            endTime: moment(`${this.currentYear}-04-02`)
+          },
+          {
+            name: 'Testitem 2',
+            startTime: moment(`${this.currentYear}-04-01`),
+            endTime: moment(`${this.currentYear}-04-04`)
+          }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
+        () => console.log('clicked')
+      ),
+      new Group(
+        'Testgroup 6',
+        [
+          {
+            name: 'Testitem 0',
+            startTime: moment(`${this.currentYear}-06-12`),
+            endTime: moment(`${this.currentYear}-07-23`),
+            class: 'type-c'
+          },
+          {
+            name: 'Testitem 1',
+            startTime: moment(`${this.currentYear - 1}-08-11`),
+            endTime: moment(`${this.currentYear}-09-02`),
+            class: 'type-a'
+          }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
+        () => console.log('clicked')
+      ),
+      new Group(
+        'Testgroup 7',
+        [
+          {
+            name: 'Testitem 0',
+            startTime: moment(`${this.currentYear - 1}-09-12`),
+            endTime: moment(`${this.currentYear - 1}-10-23`),
+            class: 'my-class-a'
+          },
+          {
+            name: 'Testitem 1',
+            startTime: moment(`${this.currentYear - 2}-10-11`),
+            endTime: moment(`${this.currentYear - 1}-11-02`),
+            class: 'my-class-a'
+          }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
+        () => console.log('clicked')
+      ),
+      new Group(
+        'Testgroup 8',
+        [
+          {
+            name: 'Testitem 0',
+            startTime: moment(`${this.currentYear}-02-12`),
+            endTime: moment(`${this.currentYear}-04-23`)
+          },
+          {
+            name: 'Testitem 1',
+            startTime: moment(`${this.currentYear}-05-11`),
+            endTime: moment(`${this.currentYear}-06-02`)
+          }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
+        () => console.log('clicked')
+      ),
+      new Group(
+        'Testgroup 9',
+        [
+          {
+            name: 'Testitem 0',
+            startTime: moment(`${this.currentYear}-02-12`),
+            endTime: moment(`${this.currentYear}-05-23`),
+            dates: [
+              moment(`${this.currentYear}-04-11`),
+              moment(`${this.currentYear}-04-12`)
+            ]
+          },
+          {
+            name: 'Testitem 1',
+            startTime: moment(`${this.currentYear}-04-11`),
+            endTime: moment(`${this.currentYear}-05-02`)
+          }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
+        () => console.log('clicked')
+      ),
+      new Group(
+        'Testgroup 10',
+        [
+          {
+            name: 'Testitem 0',
+            startTime: moment(`${this.currentYear}-06-12`),
+            endTime: moment(`${this.currentYear}-07-23`),
+            class: 'type-a',
+            dates: [
+              moment(`${this.currentYear}-06-18`),
+              moment(`${this.currentYear}-06-19`),
+              moment(`${this.currentYear}-06-23`),
+              moment(`${this.currentYear}-06-24`)
+            ]
+          },
+          {
+            name: 'Testitem 1',
+            startTime: moment(`${this.currentYear - 1}-08-11`),
+            endTime: moment(`${this.currentYear}-06-02`),
+            class: 'type-a'
+          }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
+        () => console.log('clicked')
+      ),
+      new Group(
+        'Testgroup 11',
+        [
+          {
+            name: 'Testitem 0',
+            startTime: moment(`${this.currentYear}-09-12`),
+            endTime: moment(`2021-01-23`)
+          },
+          {
+            name: 'Testitem 1',
+            startTime: moment(`${this.currentYear - 1}-10-11`),
+            endTime: moment(`${this.currentYear}-11-02`)
+          }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
+        () => console.log('clicked')
+      )
     ];
   }
 

--- a/projects/ng-time-chart-showcase/src/app/app.component.ts
+++ b/projects/ng-time-chart-showcase/src/app/app.component.ts
@@ -25,44 +25,44 @@ export class AppComponent {
   constructor() {
     moment.locale('de-ch');
     this.groups = [
-      new Group(
-        'Testgroup 0',
-        [
-          {
-            name: 'Testitem 0',
-            startTime: moment(`${this.currentYear}-02-12`),
-            endTime: moment(`${this.currentYear}-03-23`),
-            class: 'type-b'
-          },
-          {
-            name: 'Testitem 1',
-            startTime: moment(`${this.currentYear}-03-25`),
-            endTime: moment(`${this.currentYear}-03-30`),
-            class: 'type-a',
-            details: 'More information of Testitem 1',
-            onClick: () => alert('I was clicked 😊')
-          },
-          {
-            name: 'Testitem 2',
-            startTime: moment(`${this.currentYear}-04-01`),
-            endTime: moment(`${this.currentYear}-04-07`),
-            class: 'type-b'
-          },
-          {
-            name: 'Testitem 3',
-            startTime: moment(`${this.currentYear}-04-08`),
-            endTime: moment(`${this.currentYear}-04-12`),
-            class: 'type-b'
-          },
-          {
-            name: 'Testitem 4',
-            startTime: moment(`${this.currentYear}-04-02`),
-            endTime: moment(`${this.currentYear}-04-05`),
-            class: 'type-b',
-            details: 'More information of Testitem 4. A lot of text to show how this is handled.'
-          }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
-        () => alert('Group clicked')
-      ),
+      // new Group(
+      //   'Testgroup 0',
+      //   [
+      //     {
+      //       name: 'Testitem 0',
+      //       startTime: moment(`${this.currentYear}-02-12`),
+      //       endTime: moment(`${this.currentYear}-03-23`),
+      //       class: 'type-b'
+      //     },
+      //     {
+      //       name: 'Testitem 1',
+      //       startTime: moment(`${this.currentYear}-03-25`),
+      //       endTime: moment(`${this.currentYear}-03-30T01:30`),
+      //       class: 'type-a',
+      //       details: 'More information of Testitem 1',
+      //       onClick: () => alert('I was clicked 😊')
+      //     },
+      //     {
+      //       name: 'Testitem 2',
+      //       startTime: moment(`${this.currentYear}-04-01`),
+      //       endTime: moment(`${this.currentYear}-04-07`),
+      //       class: 'type-b'
+      //     },
+      //     {
+      //       name: 'Testitem 3',
+      //       startTime: moment(`${this.currentYear}-04-08`),
+      //       endTime: moment(`${this.currentYear}-04-12`),
+      //       class: 'type-b'
+      //     },
+      //     {
+      //       name: 'Testitem 4',
+      //       startTime: moment(`${this.currentYear}-04-02`),
+      //       endTime: moment(`${this.currentYear}-04-05`),
+      //       class: 'type-b',
+      //       details: 'More information of Testitem 4. A lot of text to show how this is handled.'
+      //     }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
+      //   () => alert('Group clicked')
+      // ),
       new Group(
         'Testgroup 1',
         [
@@ -76,203 +76,214 @@ export class AppComponent {
           {
             name: 'Testitem 1',
             startTime: moment(`${this.currentYear}-04-11`),
-            endTime: moment(`${this.currentYear}-04-28`),
+            endTime: moment(`${this.currentYear}-04-28T00:30`),
             details: 'Oh, there\'s a monkey in my pocket, And he\'s stealing all my change. His stare is blank and glassy, I suspect he\'s deranged 🐒',
             class: 'type-c',
-            dates: [
-              moment(`${this.currentYear}-04-11`),
-              moment(`${this.currentYear}-04-12`),
-              moment(`${this.currentYear}-04-13`),
-              moment(`${this.currentYear}-04-14`),
-              moment(`${this.currentYear}-04-15`),
-              moment(`${this.currentYear}-04-16`),
-              moment(`${this.currentYear}-04-17`),
-              moment(`${this.currentYear}-04-18`),
-              moment(`${this.currentYear}-04-19`),
-              moment(`${this.currentYear}-04-20`),
-              moment(`${this.currentYear}-04-21`),
-              moment(`${this.currentYear}-04-22`),
-              moment(`${this.currentYear}-04-23`),
-              moment(`${this.currentYear}-04-24`),
-              moment(`${this.currentYear}-04-25`),
-              moment(`${this.currentYear}-04-26`),
-              moment(`${this.currentYear}-04-27`),
-              moment(`${this.currentYear}-04-28`)
-            ]
-          }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
-        () => console.log('clicked')
-      ),
-      new Group(
-        'Testgroup 2',
-        [
-          {
-            name: 'Testitem 0',
-            startTime: moment(`${this.currentYear}-06-12`),
-            endTime: moment(`${this.currentYear}-07-23`)
-          },
-          {
-            name: 'Testitem 1',
-            startTime: moment(`${this.currentYear - 1}-08-11`),
-            endTime: moment(`${this.currentYear}-09-02`)
-          }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
-        () => console.log('clicked')
-      ),
-      new Group(
-        'Testgroup 3',
-        [
-          {
-            name: 'Testitem 0',
-            startTime: moment(`${this.currentYear}-09-12`),
-            endTime: moment(`${this.currentYear}-10-23`)
-          },
-          {
-            name: 'Testitem 1',
-            startTime: moment(`${this.currentYear}-10-11`),
-            endTime: moment(`${this.currentYear}-11-02`)
-          }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
-        () => console.log('clicked')
-      ),
-      new Group(
-        'Testgroup 4',
-        [
-          {
-            name: 'Testitem 0',
-            startTime: moment(`${this.currentYear}-02-12`),
-            endTime: moment(`${this.currentYear}-05-23`)
-          },
-          {
-            name: 'Testitem 1',
-            startTime: moment(`${this.currentYear}-12-11`),
-            endTime: moment(`${this.currentYear + 1}-03-02`)
-          }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
-        () => console.log('clicked')
-      ),
-      new Group(
-        'Testgroup 5',
-        [
-          {
-            name: 'Testitem 0',
-            startTime: moment(`${this.currentYear}-03-12`),
-            endTime: moment(`${this.currentYear}-03-23`)
-          },
-          {
-            name: 'Testitem 1',
-            startTime: moment(`${this.currentYear}-03-11`),
-            endTime: moment(`${this.currentYear}-04-02`)
+            // dates: [
+            //   moment(`${this.currentYear}-04-11`),
+            //   moment(`${this.currentYear}-04-12`),
+            //   moment(`${this.currentYear}-04-13`),
+            //   moment(`${this.currentYear}-04-14`),
+            //   moment(`${this.currentYear}-04-15`),
+            //   moment(`${this.currentYear}-04-16`),
+            //   moment(`${this.currentYear}-04-17`),
+            //   moment(`${this.currentYear}-04-18`),
+            //   moment(`${this.currentYear}-04-19`),
+            //   moment(`${this.currentYear}-04-20`),
+            //   moment(`${this.currentYear}-04-21`),
+            //   moment(`${this.currentYear}-04-22`),
+            //   moment(`${this.currentYear}-04-23`),
+            //   moment(`${this.currentYear}-04-24`),
+            //   moment(`${this.currentYear}-04-25`),
+            //   moment(`${this.currentYear}-04-26`),
+            //   moment(`${this.currentYear}-04-27`),
+            //   moment(`${this.currentYear}-04-28`)
+            // ]
           },
           {
             name: 'Testitem 2',
-            startTime: moment(`${this.currentYear}-04-01`),
-            endTime: moment(`${this.currentYear}-04-04`)
-          }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
+            startTime: moment(`${this.currentYear}-10-08T22:00`),
+            endTime: moment(`${this.currentYear}-10-10T04:30`),
+            class: 'type-b',
+            // dates: [
+            //   moment(`${this.currentYear}-10-08`),
+            //   moment(`${this.currentYear}-10-09`),
+            //   moment(`${this.currentYear}-10-10`)
+            // ]
+          },].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
         () => console.log('clicked')
       ),
-      new Group(
-        'Testgroup 6',
-        [
-          {
-            name: 'Testitem 0',
-            startTime: moment(`${this.currentYear}-06-12`),
-            endTime: moment(`${this.currentYear}-07-23`),
-            class: 'type-c'
-          },
-          {
-            name: 'Testitem 1',
-            startTime: moment(`${this.currentYear - 1}-08-11`),
-            endTime: moment(`${this.currentYear}-09-02`),
-            class: 'type-a'
-          }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
-        () => console.log('clicked')
-      ),
-      new Group(
-        'Testgroup 7',
-        [
-          {
-            name: 'Testitem 0',
-            startTime: moment(`${this.currentYear - 1}-09-12`),
-            endTime: moment(`${this.currentYear - 1}-10-23`),
-            class: 'my-class-a'
-          },
-          {
-            name: 'Testitem 1',
-            startTime: moment(`${this.currentYear - 2}-10-11`),
-            endTime: moment(`${this.currentYear - 1}-11-02`),
-            class: 'my-class-a'
-          }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
-        () => console.log('clicked')
-      ),
-      new Group(
-        'Testgroup 8',
-        [
-          {
-            name: 'Testitem 0',
-            startTime: moment(`${this.currentYear}-02-12`),
-            endTime: moment(`${this.currentYear}-04-23`)
-          },
-          {
-            name: 'Testitem 1',
-            startTime: moment(`${this.currentYear}-05-11`),
-            endTime: moment(`${this.currentYear}-06-02`)
-          }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
-        () => console.log('clicked')
-      ),
-      new Group(
-        'Testgroup 9',
-        [
-          {
-            name: 'Testitem 0',
-            startTime: moment(`${this.currentYear}-02-12`),
-            endTime: moment(`${this.currentYear}-05-23`),
-            dates: [
-              moment(`${this.currentYear}-04-11`),
-              moment(`${this.currentYear}-04-12`)
-            ]
-          },
-          {
-            name: 'Testitem 1',
-            startTime: moment(`${this.currentYear}-04-11`),
-            endTime: moment(`${this.currentYear}-05-02`)
-          }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
-        () => console.log('clicked')
-      ),
-      new Group(
-        'Testgroup 10',
-        [
-          {
-            name: 'Testitem 0',
-            startTime: moment(`${this.currentYear}-06-12`),
-            endTime: moment(`${this.currentYear}-07-23`),
-            class: 'type-a',
-            dates: [
-              moment(`${this.currentYear}-06-18`),
-              moment(`${this.currentYear}-06-19`),
-              moment(`${this.currentYear}-06-23`),
-              moment(`${this.currentYear}-06-24`)
-            ]
-          },
-          {
-            name: 'Testitem 1',
-            startTime: moment(`${this.currentYear - 1}-08-11`),
-            endTime: moment(`${this.currentYear}-06-02`),
-            class: 'type-a'
-          }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
-        () => console.log('clicked')
-      ),
-      new Group(
-        'Testgroup 11',
-        [
-          {
-            name: 'Testitem 0',
-            startTime: moment(`${this.currentYear}-09-12`),
-            endTime: moment(`2021-01-23`)
-          },
-          {
-            name: 'Testitem 1',
-            startTime: moment(`${this.currentYear - 1}-10-11`),
-            endTime: moment(`${this.currentYear}-11-02`)
-          }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
-        () => console.log('clicked')
-      )
+      // new Group(
+      //   'Testgroup 2',
+      //   [
+      //     {
+      //       name: 'Testitem 0',
+      //       startTime: moment(`${this.currentYear}-06-12`),
+      //       endTime: moment(`${this.currentYear}-07-23`)
+      //     },
+      //     {
+      //       name: 'Testitem 1',
+      //       startTime: moment(`${this.currentYear - 1}-08-11`),
+      //       endTime: moment(`${this.currentYear}-09-02`)
+      //     }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
+      //   () => console.log('clicked')
+      // ),
+      // new Group(
+      //   'Testgroup 3',
+      //   [
+      //     {
+      //       name: 'Testitem 0',
+      //       startTime: moment(`${this.currentYear}-09-12`),
+      //       endTime: moment(`${this.currentYear}-10-23`)
+      //     },
+      //     {
+      //       name: 'Testitem 1',
+      //       startTime: moment(`${this.currentYear}-10-11`),
+      //       endTime: moment(`${this.currentYear}-11-02`)
+      //     }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
+      //   () => console.log('clicked')
+      // ),
+      // new Group(
+      //   'Testgroup 4',
+      //   [
+      //     {
+      //       name: 'Testitem 0',
+      //       startTime: moment(`${this.currentYear}-02-12`),
+      //       endTime: moment(`${this.currentYear}-05-23`)
+      //     },
+      //     {
+      //       name: 'Testitem 1',
+      //       startTime: moment(`${this.currentYear}-12-11`),
+      //       endTime: moment(`${this.currentYear + 1}-03-02`)
+      //     }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
+      //   () => console.log('clicked')
+      // ),
+      // new Group(
+      //   'Testgroup 5',
+      //   [
+      //     {
+      //       name: 'Testitem 0',
+      //       startTime: moment(`${this.currentYear}-03-12`),
+      //       endTime: moment(`${this.currentYear}-03-23`)
+      //     },
+      //     {
+      //       name: 'Testitem 1',
+      //       startTime: moment(`${this.currentYear}-03-11`),
+      //       endTime: moment(`${this.currentYear}-04-02`)
+      //     },
+      //     {
+      //       name: 'Testitem 2',
+      //       startTime: moment(`${this.currentYear}-04-01`),
+      //       endTime: moment(`${this.currentYear}-04-04`)
+      //     }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
+      //   () => console.log('clicked')
+      // ),
+      // new Group(
+      //   'Testgroup 6',
+      //   [
+      //     {
+      //       name: 'Testitem 0',
+      //       startTime: moment(`${this.currentYear}-06-12`),
+      //       endTime: moment(`${this.currentYear}-07-23`),
+      //       class: 'type-c'
+      //     },
+      //     {
+      //       name: 'Testitem 1',
+      //       startTime: moment(`${this.currentYear - 1}-08-11`),
+      //       endTime: moment(`${this.currentYear}-09-02`),
+      //       class: 'type-a'
+      //     }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
+      //   () => console.log('clicked')
+      // ),
+      // new Group(
+      //   'Testgroup 7',
+      //   [
+      //     {
+      //       name: 'Testitem 0',
+      //       startTime: moment(`${this.currentYear - 1}-09-12`),
+      //       endTime: moment(`${this.currentYear - 1}-10-23`),
+      //       class: 'my-class-a'
+      //     },
+      //     {
+      //       name: 'Testitem 1',
+      //       startTime: moment(`${this.currentYear - 2}-10-11`),
+      //       endTime: moment(`${this.currentYear - 1}-11-02`),
+      //       class: 'my-class-a'
+      //     }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
+      //   () => console.log('clicked')
+      // ),
+      // new Group(
+      //   'Testgroup 8',
+      //   [
+      //     {
+      //       name: 'Testitem 0',
+      //       startTime: moment(`${this.currentYear}-02-12`),
+      //       endTime: moment(`${this.currentYear}-04-23`)
+      //     },
+      //     {
+      //       name: 'Testitem 1',
+      //       startTime: moment(`${this.currentYear}-05-11`),
+      //       endTime: moment(`${this.currentYear}-06-02`)
+      //     }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
+      //   () => console.log('clicked')
+      // ),
+      // new Group(
+      //   'Testgroup 9',
+      //   [
+      //     {
+      //       name: 'Testitem 0',
+      //       startTime: moment(`${this.currentYear}-02-12`),
+      //       endTime: moment(`${this.currentYear}-05-23`),
+      //       dates: [
+      //         moment(`${this.currentYear}-04-11`),
+      //         moment(`${this.currentYear}-04-12`)
+      //       ]
+      //     },
+      //     {
+      //       name: 'Testitem 1',
+      //       startTime: moment(`${this.currentYear}-04-11`),
+      //       endTime: moment(`${this.currentYear}-05-02`)
+      //     }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
+      //   () => console.log('clicked')
+      // ),
+      // new Group(
+      //   'Testgroup 10',
+      //   [
+      //     {
+      //       name: 'Testitem 0',
+      //       startTime: moment(`${this.currentYear}-06-12`),
+      //       endTime: moment(`${this.currentYear}-07-23`),
+      //       class: 'type-a',
+      //       dates: [
+      //         moment(`${this.currentYear}-06-18`),
+      //         moment(`${this.currentYear}-06-19`),
+      //         moment(`${this.currentYear}-06-23`),
+      //         moment(`${this.currentYear}-06-24`)
+      //       ]
+      //     },
+      //     {
+      //       name: 'Testitem 1',
+      //       startTime: moment(`${this.currentYear - 1}-08-11`),
+      //       endTime: moment(`${this.currentYear}-06-02`),
+      //       class: 'type-a'
+      //     }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
+      //   () => console.log('clicked')
+      // ),
+      // new Group(
+      //   'Testgroup 11',
+      //   [
+      //     {
+      //       name: 'Testitem 0',
+      //       startTime: moment(`${this.currentYear}-09-12`),
+      //       endTime: moment(`2021-01-23`)
+      //     },
+      //     {
+      //       name: 'Testitem 1',
+      //       startTime: moment(`${this.currentYear - 1}-10-11`),
+      //       endTime: moment(`${this.currentYear}-11-02`)
+      //     }].sort((a, b) => moment.duration(a.startTime.diff(b.startTime)).asSeconds()),
+      //   () => console.log('clicked')
+      // )
     ];
   }
 

--- a/projects/ng-time-chart/src/lib/components/item/item.component.spec.ts
+++ b/projects/ng-time-chart/src/lib/components/item/item.component.spec.ts
@@ -1,5 +1,5 @@
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {Component} from '@angular/core';
+import {Component, ViewChild} from '@angular/core';
 
 import {ItemComponent} from './item.component';
 import {Period} from '../../period';
@@ -30,11 +30,28 @@ describe('ItemComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('should calculate the day of period correctly', () => {
+    expect(component.itemComponent.getDayOfPeriod(moment('2020-10-08')))
+      .toEqual(281);
+  });
+
+  it('should calculate the day of period with late time correctly', () => {
+    expect(component.itemComponent.getDayOfPeriod(moment('2020-10-08T22:34')))
+      .toEqual(281);
+  });
+
+  it('should calculate the day of period with early time correctly', () => {
+    expect(component.itemComponent.getDayOfPeriod(moment('2020-10-08T00:12')))
+      .toEqual(281);
+  });
+
   @Component({
     selector: 'ng-host-component',
     template: '<ng-item [period]="period" [item]="item"></ng-item>'
   })
   class TestHostComponent {
+    @ViewChild(ItemComponent)
+    public itemComponent: ItemComponent;
     period: Period = new Period(moment('2020-01-01'), moment('2020-12-31'));
     item: Item = {
       name: 'Testitem',

--- a/projects/ng-time-chart/src/lib/components/item/item.component.ts
+++ b/projects/ng-time-chart/src/lib/components/item/item.component.ts
@@ -36,7 +36,7 @@ export class ItemComponent implements OnInit {
     if (!this.period.containsDate(date)) {
       return 0;
     }
-    return Math.round(date.diff(this.period.startDate, 'days', true));
+    return Math.floor(date.diff(this.period.startDate, 'days', true));
   }
 
   getDuration(item: Item): number {
@@ -50,9 +50,9 @@ export class ItemComponent implements OnInit {
   }
 
   getDaysSince(referenceDate: string | moment_.Moment, date: string | moment_.Moment): number {
-    const refDate = this.getStartDateInCurrentPeriod(moment(referenceDate));
-    const myDate = this.getStartDateInCurrentPeriod(moment(date));
-    return Math.ceil(myDate.diff(moment(refDate), 'days', true));
+    const refDate = this.getStartDateInCurrentPeriod(moment(referenceDate)).hour(12);
+    const myDate = this.getStartDateInCurrentPeriod(moment(date)).hour(12);
+    return Math.floor(myDate.diff(moment(refDate), 'days', true));
   }
 
   open(item: Item) {


### PR DESCRIPTION
Fixes issue #33 by using math.floor instead of round to calculate the number of days from the start of the displayed period to the start of the item.